### PR TITLE
Fix: Correct LORA coding rate values in sx1268_lora_cr_t

### DIFF
--- a/src/driver_sx1268.h
+++ b/src/driver_sx1268.h
@@ -250,9 +250,9 @@ typedef enum
 typedef enum
 {
     SX1268_LORA_CR_4_5 = 0x01,        /**< cr 4/5 */
-    SX1268_LORA_CR_4_6 = 0x01,        /**< cr 4/6 */
-    SX1268_LORA_CR_4_7 = 0x01,        /**< cr 4/7 */
-    SX1268_LORA_CR_4_8 = 0x01,        /**< cr 4/8 */
+    SX1268_LORA_CR_4_6 = 0x02,        /**< cr 4/6 */
+    SX1268_LORA_CR_4_7 = 0x03,        /**< cr 4/7 */
+    SX1268_LORA_CR_4_8 = 0x04,        /**< cr 4/8 */
 } sx1268_lora_cr_t;
 
 /**


### PR DESCRIPTION
## Summary
This pull request corrects the coding rate definitions in the `sx1268_lora_cr_t` enumeration. Previously, the values for coding rates 4/6, 4/7, and 4/8 were incorrectly set to `0x01`. This update assigns the correct values: 4/6 to `0x02`, 4/7 to `0x03`, and 4/8 to `0x04`.

## Motivation
I found this issue while working with the driver and wanted to correct it.

## Appreciation
Thank you for this useful project. I wanted to contribute at least this much.